### PR TITLE
Add attribute template

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,6 +10,7 @@ indent_style = space
 end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
+max_line_length = 80
 
 [*.md]
-trim_trailing_whitespace = false
+trim_trailing_whitespace = true

--- a/Template.md
+++ b/Template.md
@@ -1,3 +1,6 @@
+# A template for an attribute definition
+
+```php
 <?php
 
 declare(strict_types=1);
@@ -7,7 +10,7 @@ namespace Fig\Attributes;
 /**
  * One-Line summary of what the attribute does (PLAIN TEXT!)
  *
- * ## Target audience
+ * ## Target audience.
  *
  * Implementors
  * : Who should handle this attribute? Example: "static analysis tools"
@@ -22,7 +25,7 @@ namespace Fig\Attributes;
  * Use citations[^citation] or [Links](https://example.com) in your text to make
  * sure people understand the relevance and where you got your ideas from.
  *
- * ## When should the attribute be applied ?
+ * ## When should the attribute be applied?
  *
  * If your Attribute has preconditions for usage you MUST use the keywords
  * described in [RFC 2119](https://datatracker.ietf.org/doc/html/rfc2119).
@@ -48,17 +51,20 @@ namespace Fig\Attributes;
 class Template
 {
     /**
-     * You MUST describe parameters to your Attribute extensively! You SHOULD use
-     * the well-known Annotations for that.
-     *
-     * Also, you SHOULD describe what the different functions do.
-     *
+     * Describe your methods extensively.
+     * 
+     * You also MUST describe parameters to your Attribute extensively! You 
+     * SHOULD use the DocBlock-format as described in PSR-5 for that.
+     * 
      * @param string $name
-     *     The name of this template
+     *     The name of this template.
+     * 
+     *     Parameter descriptions can span multiple lines. Make sure to
+     *     separate the subject from the text by a blank line.
      * @param boolean $expose
      *     Whether to expose this as an example or not.
      * @param int[] $luckyNumbers
-     *     The lucky numbers of this week
+     *     The lucky numbers of this week.
      */
     public function __construct(
         public readonly string $name,
@@ -66,3 +72,4 @@ class Template
         public readonly array $luckyNumbers
     ) {}
 }
+```

--- a/Template.php
+++ b/Template.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Fig\Attributes;
 
 /**
- * One-Line summary of what the attribute does
+ * One-Line summary of what the attribute does (PLAIN TEXT!)
  *
  * ## Target audience
  *
@@ -13,12 +13,16 @@ namespace Fig\Attributes;
  * : Who should handle this attribute? Example: "static analysis tools"
  * Users
  * : Who adds this attribute to their code? Example: "packages that want to
- *   safeguard their functions via static analysis
+ *   safeguard their functions via static analysis"
+ *
+ * ## Purpose
  *
  * Long explanation of what the attribute does and why it is relevant.
  *
  * Use citations[^citation] or [Links](https://example.com) in your text to make
  * sure people understand the relevance and where you got your ideas from.
+ *
+ * ## When should the attribute be applied ?
  *
  * If your Attribute has preconditions for usage you MUST use the keywords
  * described in [RFC 2119](https://datatracker.ietf.org/doc/html/rfc2119).
@@ -26,21 +30,39 @@ namespace Fig\Attributes;
  *
  * **Note:** DocBlock content MUST be Markdown formatted. Check out the
  *   [Markdown-Guide](https://www.markdownguide.org/) for possible formatting
+ *   and keep in mind that the short description should not contain markdown.
+ *
+ * Keep your lines at a maximum of 80 Characters. It increases readability on
+ * smaller windows.
  *
  * Please also use code-snippets where appropriate
  *
  * ```php
- *     <?php
- *     echo 'Hello World';
+ * <?php
+ * echo 'Hello World';
  * ```
- *
- * You MUST describe parameters to your Attribute extensively! You SHOULD use
- * the well-known Annotations for that
- *
- * @param string $example_1 Does x and y
- * @param boolean $example_2
  *
  * [^citation] https://en.wikipedia.org/wiki/Citation
  */
 #[\Attribute(\Attribute::TARGET_CLASS)]
-final class Template {}
+class Template
+{
+    /**
+     * You MUST describe parameters to your Attribute extensively! You SHOULD use
+     * the well-known Annotations for that.
+     *
+     * Also, you SHOULD describe what the different functions do.
+     *
+     * @param string $name
+     *     The name of this template
+     * @param boolean $expose
+     *     Whether to expose this as an example or not.
+     * @param int[] $luckyNumbers
+     *     The lucky numbers of this week
+     */
+    public function __construct(
+        public readonly string $name,
+        public readonly bool $expose,
+        public readonly array $luckyNumbers
+    ) {}
+}

--- a/Template.php
+++ b/Template.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fig\Attributes;
+
+/**
+ * One-Line summary of what the attribute does
+ *
+ * ## Target audience
+ *
+ * Implementors
+ * : Who should handle this attribute? Example: "static analysis tools"
+ * Users
+ * : Who adds this attribute to their code? Example: "packages that want to
+ *   safeguard their functions via static analysis
+ *
+ * Long explanation of what the attribute does and why it is relevant.
+ *
+ * Use citations[^citation] or [Links](https://example.com) in your text to make
+ * sure people understand the relevance and where you got your ideas from.
+ *
+ * If your Attribute has preconditions for usage you MUST use the keywords
+ * described in [RFC 2119](https://datatracker.ietf.org/doc/html/rfc2119).
+ * You SHOULD list them prominently.
+ *
+ * **Note:** DocBlock content MUST be Markdown formatted. Check out the
+ *   [Markdown-Guide](https://www.markdownguide.org/) for possible formatting
+ *
+ * Please also use code-snippets where appropriate
+ *
+ * ```php
+ *     <?php
+ *     echo 'Hello World';
+ * ```
+ *
+ * You MUST describe parameters to your Attribute extensively! You SHOULD use
+ * the well-known Annotations for that
+ *
+ * @param string $example_1 Does x and y
+ * @param boolean $example_2
+ *
+ * [^citation] https://en.wikipedia.org/wiki/Citation
+ */
+#[\Attribute(\Attribute::TARGET_CLASS)]
+final class Template {}


### PR DESCRIPTION
This adds a template for an attribute definition that can help people get started when they want to create a PR for a new attribute.

It should contain all possible options that help someone document the new attribute as good as possible. This will for sure be a living document as we won't think of all possibilities and options right from the start.