### PR TITLE
Add a paragraph about attribute takeover

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ Any attribute proposed must be approved by a majority of the working group, and 
 
 Ideally, proposals should be discussed in the [PHP-FIG Discord](https://discord.gg/php-fig), `#per-attributes` channel, prior to proposal.
 
+Existing attributes can be transfered to the FIG. Such attributes will be listed for a reasonable amount of time
+in an IN_TRANSITION.md document. The process for a take-over is in essence the same as for not-yet existing attributes.
+
 ## Contributing
 
 Please see [CONTRIBUTING](CONTRIBUTING.md) for details.


### PR DESCRIPTION
It mmight happen that already existing attributes shall be taken over by the FIG to allow greater reach or provide better maintenance. This is in general something that we allow and already thought about. Such attributes can be published on one central page to make people more aware of them once the process has been started of taking the attribute over.